### PR TITLE
Flush after setting background image, more permissive setuptools dependency

### DIFF
--- a/nerfview/_renderer.py
+++ b/nerfview/_renderer.py
@@ -160,3 +160,4 @@ class Renderer(threading.Thread):
                 jpeg_quality=70 if task.action in ["static", "update"] else 40,
                 depth=depth,
             )
+            self.client.flush()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==65.6.3"]
+requires = ["setuptools>=68.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -18,7 +18,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-dependencies = ["viser>=0.2.1", "jaxtyping>=0.2.15"]
+dependencies = ["viser>=0.2.1"]
 
 [project.optional-dependencies]
 dev = ["black", "isort", "ipdb"]


### PR DESCRIPTION
- The flush can reduce latency by up 1/60 sec
- The pinned setuptools version was preventing me from installing nerfview in my env, I relaxed it!